### PR TITLE
File url

### DIFF
--- a/ZappAppConnector/Protocols/ZAAppDelegateConnectorURLProtocol.h
+++ b/ZappAppConnector/Protocols/ZAAppDelegateConnectorURLProtocol.h
@@ -10,5 +10,6 @@
 @protocol ZAAppDelegateConnectorURLProtocol
 
 - (NSString *)appUrlSchemePrefix;
+- (NSURL *)fileUrlWithName:(NSString *)fileName extension:(NSString *)extension;
 
 @end


### PR DESCRIPTION
- Allows to load a file through the delegate, instead of accessing the bundle directly
- One usage example: the facebook login plugin asks the delegate to get a local video file url to play in the presented screen