### PR TITLE
feat: account kit protocol

### DIFF
--- a/ZappAppConnector.xcodeproj/project.pbxproj
+++ b/ZappAppConnector.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		66AE73F03F2F5DDF217F7140 /* Pods_ZappAppConnectorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B291F0DDD60F5E87DB25C224 /* Pods_ZappAppConnectorTests.framework */; };
+		71B074911FF2B27A008ADA28 /* ZAAppDelegateConnectorFacebookAccountKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B074901FF2B27A008ADA28 /* ZAAppDelegateConnectorFacebookAccountKitProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE4A9A991F0AD60A002FDE36 /* ZAAppDelegateConnectorURLProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4A9A981F0AD60A002FDE36 /* ZAAppDelegateConnectorURLProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE50034C1F0A0F3F00825C38 /* ZAAppDelegateConnectorTimeProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CE50034B1F0A0F3F00825C38 /* ZAAppDelegateConnectorTimeProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE50034E1F0A10ED00825C38 /* ZAAppDelegateConnectorActionProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CE50034D1F0A10ED00825C38 /* ZAAppDelegateConnectorActionProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -37,6 +38,7 @@
 /* Begin PBXFileReference section */
 		0824DA4ED3E6BE8B6C57EDDA /* Pods-ZappAppConnector.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZappAppConnector.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ZappAppConnector/Pods-ZappAppConnector.debug.xcconfig"; sourceTree = "<group>"; };
 		365E8C5F3B06CC6F3F5965D4 /* Pods-ZappAppConnectorTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZappAppConnectorTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ZappAppConnectorTests/Pods-ZappAppConnectorTests.debug.xcconfig"; sourceTree = "<group>"; };
+		71B074901FF2B27A008ADA28 /* ZAAppDelegateConnectorFacebookAccountKitProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZAAppDelegateConnectorFacebookAccountKitProtocol.h; sourceTree = "<group>"; };
 		90D7D48DF8594EFF11EAA009 /* Pods-ZappAppConnectorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZappAppConnectorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ZappAppConnectorTests/Pods-ZappAppConnectorTests.release.xcconfig"; sourceTree = "<group>"; };
 		B291F0DDD60F5E87DB25C224 /* Pods_ZappAppConnectorTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ZappAppConnectorTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE4A9A981F0AD60A002FDE36 /* ZAAppDelegateConnectorURLProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZAAppDelegateConnectorURLProtocol.h; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 		FA9590541F08D81F00879372 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
+				71B074901FF2B27A008ADA28 /* ZAAppDelegateConnectorFacebookAccountKitProtocol.h */,
 				FA9A96501F1612F500E64F9D /* ZAAppDelegateConnectorFirebaseRemoteConfigurationProtocol.h */,
 				FA9590591F08DA6A00879372 /* ZAAppDelegateConnectorLocalizationProtocol.h */,
 				FA9590551F08D81F00879372 /* ZAAppDelegateConnectorNavigationProtocol.h */,
@@ -175,6 +178,7 @@
 				FA95905A1F08DA6A00879372 /* ZAAppDelegateConnectorLocalizationProtocol.h in Headers */,
 				CE4A9A991F0AD60A002FDE36 /* ZAAppDelegateConnectorURLProtocol.h in Headers */,
 				FA9590571F08D81F00879372 /* ZAAppDelegateConnectorNavigationProtocol.h in Headers */,
+				71B074911FF2B27A008ADA28 /* ZAAppDelegateConnectorFacebookAccountKitProtocol.h in Headers */,
 				FA9590461F08D7E600879372 /* ZappAppConnector.h in Headers */,
 				CE5003501F0A115E00825C38 /* ZAAppDelegateConnectorAnimationProtocol.h in Headers */,
 				CE50034C1F0A0F3F00825C38 /* ZAAppDelegateConnectorTimeProtocol.h in Headers */,

--- a/ZappAppConnector/AppConnector/ZAAppConnector.h
+++ b/ZappAppConnector/AppConnector/ZAAppConnector.h
@@ -15,6 +15,7 @@
 #import "ZAAppDelegateConnectorAnimationProtocol.h"
 #import "ZAAppDelegateConnectorURLProtocol.h"
 #import "ZAAppDelegateConnectorFirebaseRemoteConfigurationProtocol.h"
+#import "ZAAppDelegateConnectorFacebookAccountKitProtocol.h"
 
 @interface ZAAppConnector : NSObject
 
@@ -26,7 +27,7 @@
 @property (nonatomic, weak) id<ZAAppDelegateConnectorAnimationProtocol> animationDelegate;
 @property (nonatomic, weak) id<ZAAppDelegateConnectorURLProtocol> urlDelegate;
 @property (nonatomic, weak) id<ZAAppDelegateConnectorFirebaseRemoteConfigurationProtocol> firebaseRemoteConfigurationDelegate;
-
+@property (nonatomic, weak) id<ZAAppDelegateConnectorFacebookAccountKitProtocol> facebookAccountKitDelegate;
 
 + (instancetype)sharedInstance;
 

--- a/ZappAppConnector/Protocols/ZAAppDelegateConnectorFacebookAccountKitProtocol.h
+++ b/ZappAppConnector/Protocols/ZAAppDelegateConnectorFacebookAccountKitProtocol.h
@@ -1,0 +1,36 @@
+//
+//  ZAAppDelegateConnectorFacebookAccountKitProtocol.h
+//  ZappAppConnector
+//
+//  Created by sborkin on 26/12/2017.
+//  Copyright © 2017 Applicaster Ltd. All rights reserved.
+//
+
+#import <Foundation/NSObject.h>
+
+typedef NS_ENUM(NSUInteger, ZAAccountKitLoginType) {
+    ZAAccountKitLoginTypeEmail,
+    ZAAccountKitLoginTypePhone
+};
+
+typedef NS_ENUM(NSUInteger, ZAAccountKitStatus) {
+    ZAAccountKitStatusFailed,
+    ZAAccountKitStatusCompleted
+};
+
+
+@interface ZAAccountKitUser : NSObject
+
+@property (nonatomic, strong) NSString *email;
+@property (nonatomic, strong) NSString *phone;
+
+@end
+
+typedef void(^AccountKitLoginCompletionBlock)(ZAAccountKitStatus, ZAAccountKitUser *);
+
+@protocol ZAAppDelegateConnectorFacebookAccountKitProtocol
+
+- (BOOL)isAuthenticated;
+- (void)performLoginWithType:(ZAAccountKitLoginType)type completion:(AccountKitLoginCompletionBlock)completion;
+
+@end


### PR DESCRIPTION
- Add new Account kit protocol
- Exposes the framework from the App level to the plugins
- Currently used by FacebookLogin plugin to enable login using email/phone