### PR TITLE
fix: allow the url return value be null for the app connector file url

### DIFF
--- a/ZappAppConnector/Protocols/ZAAppDelegateConnectorURLProtocol.h
+++ b/ZappAppConnector/Protocols/ZAAppDelegateConnectorURLProtocol.h
@@ -10,6 +10,6 @@
 @protocol ZAAppDelegateConnectorURLProtocol
 
 - (NSString *)appUrlSchemePrefix;
-- (NSURL *)fileUrlWithName:(NSString *)fileName extension:(NSString *)extension;
+- (nullable NSURL *)fileUrlWithName:(NSString *)fileName extension:(NSString *)extension;
 
 @end


### PR DESCRIPTION
- Will allow the implementation for return nil in case the file not found