### PR TITLE
feat: add analytics delegate which should be used instead of the manager directly

### DIFF
--- a/ZappAppConnector.xcodeproj/project.pbxproj
+++ b/ZappAppConnector.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		07E094671FEC161F006C1776 /* ZAAppDelegateConnectorChromecastProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 07E094661FEC161F006C1776 /* ZAAppDelegateConnectorChromecastProtocol.h */; };
 		66AE73F03F2F5DDF217F7140 /* Pods_ZappAppConnectorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B291F0DDD60F5E87DB25C224 /* Pods_ZappAppConnectorTests.framework */; };
+		711C9972202E0D1F008B5D73 /* ZAAppDelegateConnectorAnalyticsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711C9971202E0D1F008B5D73 /* ZAAppDelegateConnectorAnalyticsProtocol.swift */; };
 		71797F471FF41FC5004D3232 /* ZAAccountKitUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71797F461FF41FC5004D3232 /* ZAAccountKitUser.swift */; };
 		71B074911FF2B27A008ADA28 /* ZAAppDelegateConnectorFacebookAccountKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B074901FF2B27A008ADA28 /* ZAAppDelegateConnectorFacebookAccountKitProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE4A9A991F0AD60A002FDE36 /* ZAAppDelegateConnectorURLProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4A9A981F0AD60A002FDE36 /* ZAAppDelegateConnectorURLProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -41,6 +42,7 @@
 		07E094661FEC161F006C1776 /* ZAAppDelegateConnectorChromecastProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZAAppDelegateConnectorChromecastProtocol.h; sourceTree = "<group>"; };
 		0824DA4ED3E6BE8B6C57EDDA /* Pods-ZappAppConnector.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZappAppConnector.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ZappAppConnector/Pods-ZappAppConnector.debug.xcconfig"; sourceTree = "<group>"; };
 		365E8C5F3B06CC6F3F5965D4 /* Pods-ZappAppConnectorTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZappAppConnectorTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ZappAppConnectorTests/Pods-ZappAppConnectorTests.debug.xcconfig"; sourceTree = "<group>"; };
+		711C9971202E0D1F008B5D73 /* ZAAppDelegateConnectorAnalyticsProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZAAppDelegateConnectorAnalyticsProtocol.swift; sourceTree = "<group>"; };
 		71797F461FF41FC5004D3232 /* ZAAccountKitUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZAAccountKitUser.swift; sourceTree = "<group>"; };
 		71B074901FF2B27A008ADA28 /* ZAAppDelegateConnectorFacebookAccountKitProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZAAppDelegateConnectorFacebookAccountKitProtocol.h; sourceTree = "<group>"; };
 		90D7D48DF8594EFF11EAA009 /* Pods-ZappAppConnectorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZappAppConnectorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ZappAppConnectorTests/Pods-ZappAppConnectorTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				CE50034F1F0A115E00825C38 /* ZAAppDelegateConnectorAnimationProtocol.h */,
 				CE4A9A981F0AD60A002FDE36 /* ZAAppDelegateConnectorURLProtocol.h */,
 				07E094661FEC161F006C1776 /* ZAAppDelegateConnectorChromecastProtocol.h */,
+				711C9971202E0D1F008B5D73 /* ZAAppDelegateConnectorAnalyticsProtocol.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 			files = (
 				71797F471FF41FC5004D3232 /* ZAAccountKitUser.swift in Sources */,
 				FA9590531F08D80500879372 /* ZAAppConnector.m in Sources */,
+				711C9972202E0D1F008B5D73 /* ZAAppDelegateConnectorAnalyticsProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -539,6 +543,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.applicaster.ZappAppConnector;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -557,6 +562,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.applicaster.ZappAppConnector;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/ZappAppConnector/AppConnector/ZAAppConnector.h
+++ b/ZappAppConnector/AppConnector/ZAAppConnector.h
@@ -18,6 +18,8 @@
 #import "ZAAppDelegateConnectorChromecastProtocol.h"
 #import "ZAAppDelegateConnectorFacebookAccountKitProtocol.h"
 
+@protocol ZAAppDelegateConnectorAnalyticsProtocol;
+
 @interface ZAAppConnector : NSObject
 
 @property (nonatomic, weak) id<ZAAppDelegateConnectorLocalizationProtocol> localizationDelegate;
@@ -30,6 +32,7 @@
 @property (nonatomic, weak) id<ZAAppDelegateConnectorFirebaseRemoteConfigurationProtocol> firebaseRemoteConfigurationDelegate;
 @property (nonatomic, weak) id<ZAAppDelegateConnectorChromecastProtocol> chromecastDelegate;
 @property (nonatomic, weak) id<ZAAppDelegateConnectorFacebookAccountKitProtocol> facebookAccountKitDelegate;
+@property (nonatomic, weak) id<ZAAppDelegateConnectorAnalyticsProtocol> analyticsDelegate;
 
 + (instancetype)sharedInstance;
 

--- a/ZappAppConnector/Protocols/ZAAppDelegateConnectorAnalyticsProtocol.swift
+++ b/ZappAppConnector/Protocols/ZAAppDelegateConnectorAnalyticsProtocol.swift
@@ -7,7 +7,14 @@
 
 import Foundation
 
+// Allows lower layer classes like plugins to send analytics using the analytics providers set for the app
 @objc public protocol ZAAppDelegateConnectorAnalyticsProtocol {
+    // The event will be sent using all the analytics providers added as plugins
+    // It might be the event is blacklisted in the provider plugin configuration, in that case it will be ignored
     @objc func trackEvent(name: String, parameters: Dictionary<String, Any>)
-    @objc func trackScreenView(name: String, parameters: Dictionary<String, Any>)
+    
+    // Sends an event with the parameter title indicating the selected screen was presented to the user
+    // Each provider names the event itself differently (for example Page View)
+    // The event will also include a Trigger parameter which indicates the title of the previous screen
+    @objc func trackScreenView(screenTitle: String, parameters: Dictionary<String, Any>)
 }

--- a/ZappAppConnector/Protocols/ZAAppDelegateConnectorAnalyticsProtocol.swift
+++ b/ZappAppConnector/Protocols/ZAAppDelegateConnectorAnalyticsProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ZAAppDelegateConnectorAnalyticsProtocol.swift
+//  ZappAppConnector
+//
+//  Created by Simon Borkin on 2/9/18.
+//
+
+import Foundation
+
+@objc public protocol ZAAppDelegateConnectorAnalyticsProtocol {
+    @objc func trackEvent(name: String, parameters: Dictionary<String, Any>)
+    @objc func trackScreenView(name: String, parameters: Dictionary<String, Any>)
+}


### PR DESCRIPTION
- it should be used by plugins to send analytic events, and they shouldn't access the analytics manager directly